### PR TITLE
Temporary rolled back prod image name.

### DIFF
--- a/.github/workflows/build_production.yml
+++ b/.github/workflows/build_production.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  IMAGE_NAME: onchain-mon
+  IMAGE_NAME: forta-finding-forwarder
   IMAGE_TAG: stable
 
 jobs:


### PR DESCRIPTION
## Summary

Temporary rolled back prod image name. I don't have permission to create or rename the old one.

## Changes ([help](https://www.conventionalcommits.org/en/v1.0.0/#summary))

- fix: rolled back prod image nam
