### PR TITLE
fix(feeder): prevent inf loop when GetBlockReceipts is failed

### DIFF
--- a/internal/app/feeder/feeder.go
+++ b/internal/app/feeder/feeder.go
@@ -121,6 +121,9 @@ func (w *Feeder) Run(ctx context.Context, g *errgroup.Group) {
 				if err != nil {
 					w.metricsStore.PublishedBlocks.With(prometheus.Labels{metrics.Status: metrics.StatusFail}).Inc()
 					w.log.Error(fmt.Sprintf("GetBlockReceipts error: %v", err))
+
+					prevBlockNumber = block.Result.GetNumber()
+					w.updateTickerAfterBlock(timer, block.Result)
 					continue
 				}
 


### PR DESCRIPTION
## Summary

[prevent inf loop when GetBlockReceipts is failed](https://github.com/lidofinance/onchain-mon/pull/89/commits/ad1ddb03fa35b99ac5ec8da3e4ea8a7958d2a14b)