### PR TITLE
feat(forwarder): tweak sleep time when reaching tg, discord limits

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -65,7 +65,6 @@ func main() {
 		MaxConnsPerHost:       12,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 

--- a/internal/pkg/notifiler/telegram.go
+++ b/internal/pkg/notifiler/telegram.go
@@ -79,24 +79,21 @@ func (t *Telegram) SendFinding(ctx context.Context, alert *databus.FindingDtoJso
 }
 
 func (t *Telegram) send(ctx context.Context, message string, useMarkdown bool) error {
-	form := url.Values{}
-	form.Set("chat_id", "-"+t.chatID)
-	form.Set("text", message)
-	form.Set("disable_web_page_preview", "true")
-	form.Set("disable_notification", "true")
+	requestURL := fmt.Sprintf(
+		"https://api.telegram.org/bot%s/sendMessage?disable_web_page_preview=true&disable_notification=true&chat_id=-%s&text=%s",
+		t.botToken,
+		t.chatID,
+		url.QueryEscape(message),
+	)
 	if useMarkdown {
-		form.Set("parse_mode", "Markdown")
+		requestURL += `&parse_mode=markdown`
 	}
 
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		"https://api.telegram.org/bot"+t.botToken+"/sendMessage",
-		strings.NewReader(form.Encode()),
-	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("could not create telegram request: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	start := time.Now()


### PR DESCRIPTION
## Summary

Restored method for sending msg to tg via Get method. Removed timeout for getting headers

