### PR TITLE
fix(telegram): escape all MarkdownV1 entities in finding-controlled fields

### DIFF
--- a/internal/pkg/notifiler/telegram.go
+++ b/internal/pkg/notifiler/telegram.go
@@ -55,8 +55,20 @@ const WarningTelegramMessage = "Warn: Msg >=4096, pls review description message
 const TelegramLabel = `telegram`
 
 func (t *Telegram) SendFinding(ctx context.Context, alert *databus.FindingDtoJson) error {
+	// Escape MarkdownV1 entity characters in the free-text, finding-controlled
+	// fields before they are composed into the message. This is done on a copy so
+	// the change is scoped to the Telegram notifier and does not affect the other
+	// channels that also call FormatAlert. FormatAlert still builds its own trusted
+	// inline links (block/tx) around these already-escaped values, so a crafted
+	// finding can no longer smuggle links or formatting into the alert.
+	safeAlert := *alert
+	safeAlert.Name = escapeMarkdownV1Field(alert.Name)
+	safeAlert.Description = escapeMarkdownV1Field(alert.Description)
+	safeAlert.Team = escapeMarkdownV1Field(alert.Team)
+	safeAlert.BotName = escapeMarkdownV1Field(alert.BotName)
+
 	message := TruncateMessageWithAlertID(
-		fmt.Sprintf("%s\n\n%s", alert.Name, FormatAlert(alert, t.source, t.blockExplorer)),
+		fmt.Sprintf("%s\n\n%s", safeAlert.Name, FormatAlert(&safeAlert, t.source, t.blockExplorer)),
 		MaxTelegramMessageLength,
 		WarningTelegramMessage,
 	)
@@ -151,6 +163,14 @@ func (t *Telegram) GetType() registry.NotificationChannel {
 //
 // V2 - is more reach for special symbols, more you can find by link
 // https://core.telegram.org/bots/update56kabdkb12ibuisabdubodbasbdaosd#markdownv2-style
+//
+// NOTE: this escapes an already-composed message and therefore only escapes the
+// underscore, because escaping the other V1 entity characters here would also
+// break the intentional inline links (`[block](url)`, `[tx](url)`) that
+// FormatAlert composes into the trusted footer. Escaping of the free-text,
+// finding-controlled fields (Name, Description, Team, BotName) is done at their
+// source in SendFinding via escapeMarkdownV1Field, so those cannot smuggle
+// markup into the message.
 func escapeMarkdownV1(input string) string {
 	specialChars := map[string]struct{}{
 		`_`: {},
@@ -159,6 +179,36 @@ func escapeMarkdownV1(input string) string {
 	var escaped strings.Builder
 	for _, char := range input {
 		if _, ok := specialChars[string(char)]; ok {
+			escaped.WriteString(`\`)
+		}
+
+		escaped.WriteRune(char)
+	}
+
+	return escaped.String()
+}
+
+// escapeMarkdownV1Field escapes every Telegram MarkdownV1 entity character in a
+// free-text field that originates from a finding (Name, Description). Unlike
+// escapeMarkdownV1, which runs over the fully composed message and must preserve
+// the intentional links, this runs over untrusted text before it is placed into
+// the message, so it neutralises `*`, backtick and `[` in addition to `_`.
+//
+// Without this, a finding whose text contains e.g. `[click](https://evil)` or
+// backtick-fenced content renders as active markup in the notification channel,
+// letting a crafted finding inject clickable links or formatting into an
+// otherwise trusted alert.
+func escapeMarkdownV1Field(input string) string {
+	specialChars := map[rune]struct{}{
+		'_': {},
+		'*': {},
+		'`': {},
+		'[': {},
+	}
+
+	var escaped strings.Builder
+	for _, char := range input {
+		if _, ok := specialChars[char]; ok {
 			escaped.WriteString(`\`)
 		}
 

--- a/internal/pkg/notifiler/telegram_internal_test.go
+++ b/internal/pkg/notifiler/telegram_internal_test.go
@@ -1,0 +1,54 @@
+package notifiler
+
+import "testing"
+
+func Test_escapeMarkdownV1Field(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text is unchanged",
+			input: "Vault balance dropped",
+			want:  "Vault balance dropped",
+		},
+		{
+			name:  "underscore is escaped",
+			input: "low_balance_alert",
+			want:  `low\_balance\_alert`,
+		},
+		{
+			name:  "injected inline link is neutralised",
+			input: "[click me](https://evil.example)",
+			want:  `\[click me](https://evil.example)`,
+		},
+		{
+			name:  "asterisk emphasis is neutralised",
+			input: "*urgent*",
+			want:  `\*urgent\*`,
+		},
+		{
+			name:  "backtick code span is neutralised",
+			input: "run `rm -rf` now",
+			want:  "run \\`rm -rf\\` now",
+		},
+		{
+			name:  "all entity characters together",
+			input: "_*`[",
+			want:  "\\_\\*\\`\\[",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := escapeMarkdownV1Field(tt.input); got != tt.want {
+				t.Errorf("escapeMarkdownV1Field(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`escapeMarkdownV1` escapes only the underscore, and it runs over the **fully composed** message — so escaping more characters there would also break the intentional `[block](url)` / `[tx](url)` links that `FormatAlert` builds into the footer. The consequence is that the free-text, finding-controlled fields (`Name`, `Description`, `Team`, `BotName`) reach the Telegram message with `*`, `` ` `` and `[` unescaped.

A finding whose text contains, for example, `[click me](https://evil.example)` or a `` `code` `` span therefore renders as **active Markdown** in the Telegram alert channel — letting a crafted finding inject clickable links or formatting into an otherwise trusted alert.

## Fix

- Add `escapeMarkdownV1Field`, which escapes every Telegram MarkdownV1 entity character (`_`, `*`, `` ` ``, `[`) — intended for untrusted free-text, unlike the existing `escapeMarkdownV1` which must preserve the composed message's links.
- Apply it in `SendFinding` to the finding-controlled fields, on a **per-notifier copy** of the alert, *before* `FormatAlert` composes its own trusted links around them. This keeps the intentional block/tx links working.
- Scope is the Telegram notifier only — `FormatAlert` is shared with Discord/Slack/OpsGenie, so the escaping is applied on the copy in `SendFinding` rather than in `FormatAlert`, leaving those channels unchanged.
- Add unit tests for the new escaping (plain text unchanged; `_ * ` `` ` `` `[` neutralised; injected link neutralised).

## Impact / severity

I want to be straight about scope: whether this is externally exploitable depends on your deployment's trust boundary. Findings are ingested via NATS JetStream (`consumer.go`), so if that bus is only reachable by your own trusted bots, an external attacker cannot inject a finding and this is defense-in-depth / hardening. It becomes a real injection vector if any finding field is ever populated from on-chain or otherwise attacker-influenceable data (e.g. a bot that echoes a token name or calldata into the description), or if NATS ingest is reachable more widely. Either way, escaping untrusted text before it enters a Markdown message is the correct posture.

## Note on verification

I don't have a Go toolchain in the environment where I prepared this, so I have **not** run `go build` / `go test` locally — please let CI (or a local `make test`) confirm before merging. The change is small and self-contained; I checked it by hand for correctness and matched the existing code style. Happy to adjust naming, escape the field set differently, or fold the escaping elsewhere if you prefer.
